### PR TITLE
Fixed reference to paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
             <li><em>Chat:</em> <a href="https://gitter.im/openturns/community">gitter</a></li>
             <li><em>Twitter:</em> <a href="https://twitter.com/openturns_org">@openturns_org</a></li>
             <li><em>StackOverflow:</em> <a href="https://stackoverflow.com/questions/tagged/openturns">[openturns]</a></li>
-            <li><em>Publications:</em> <a href="https://arxiv.org/abs/1501.05242">baudin2015</a></li>
+            <li><em>Publications:</em> <a href="https://rd.springer.com/referenceworkentry/10.1007/978-3-319-12385-1_64">(Baudin et al., 2015)</a></li>
             <li><em>Related software:</em> <a href="https://raven.inl.gov">RAVEN</a>, <a href="https://www.uqlab.com/">UQLab</a>, <a href="https://www.persalys.fr">Persalys</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Replaced the reference of the paper from the preprint:
https://arxiv.org/abs/1501.05242
to the published paper:
https://rd.springer.com/referenceworkentry/10.1007/978-3-319-12385-1_64